### PR TITLE
Fix tutorials by bumping version and adding maxTimeout

### DIFF
--- a/package/Channel.tcl
+++ b/package/Channel.tcl
@@ -1,4 +1,4 @@
-package provide rmq 1.3.1
+package provide rmq 1.3.2
 
 package require TclOO
 

--- a/package/Connection.tcl
+++ b/package/Connection.tcl
@@ -1,4 +1,4 @@
-package provide rmq 1.3.1
+package provide rmq 1.3.2
 
 package require TclOO
 package require tls

--- a/package/Connection.tcl
+++ b/package/Connection.tcl
@@ -39,6 +39,9 @@ oo::class create ::rmq::Connection {
 	# this is set to true after performing the handshake
 	variable connected
 
+	#maximum connect timeout.
+	variable maxTimeout
+	
 	# whether the connection is blocked
 	variable blocked
 

--- a/package/pkgIndex.tcl
+++ b/package/pkgIndex.tcl
@@ -8,4 +8,4 @@
 # script is sourced, the variable $dir must contain the
 # full path name of this file's directory.
 
-package ifneeded rmq 1.0 [list source [file join $dir Channel.tcl]]\n[list source [file join $dir Connection.tcl]]\n[list source [file join $dir Login.tcl]]\n[list source [file join $dir constants.tcl]]\n[list source [file join $dir decoders.tcl]]\n[list source [file join $dir encoders.tcl]]
+package ifneeded rmq 1.3.2 [list source [file join $dir Channel.tcl]]\n[list source [file join $dir Connection.tcl]]\n[list source [file join $dir Login.tcl]]\n[list source [file join $dir constants.tcl]]\n[list source [file join $dir decoders.tcl]]\n[list source [file join $dir encoders.tcl]]


### PR DESCRIPTION
Connection.tcl and Channel.tcl still have 1.3.1 version number which causes a conflict during load of rmq package. 

maxTimeout was missing from the Connection class which was causing an error in the Connection::connect method.